### PR TITLE
Feature/Neoforge Support

### DIFF
--- a/Compile Info/Specs.py
+++ b/Compile Info/Specs.py
@@ -2,7 +2,7 @@ import pyinstaller_versionfile
 
 pyinstaller_versionfile.create_versionfile(
     output_file="versionfile.txt",
-    version="1.3.3.2",
+    version="1.4.3.3",
     company_name="Noah Blaszak",
     file_description="Hominum Minecraft Launcher",
     internal_name="Hominum Client",

--- a/Compile Info/versionfile.txt
+++ b/Compile Info/versionfile.txt
@@ -7,8 +7,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0. Must always contain 4 elements.
-    filevers=(1,3,3,2),
-    prodvers=(1,3,3,2),
+    filevers=(1,4,3,3),
+    prodvers=(1,4,3,3),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -32,12 +32,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'Noah Blaszak'),
         StringStruct(u'FileDescription', u'Hominum Minecraft Launcher'),
-        StringStruct(u'FileVersion', u'1.3.3.2'),
+        StringStruct(u'FileVersion', u'1.4.3.3'),
         StringStruct(u'InternalName', u'Hominum Client'),
         StringStruct(u'LegalCopyright', u'© Noah Blaszak. All rights reserved.'),
         StringStruct(u'OriginalFilename', u'Hominum.exe'),
         StringStruct(u'ProductName', u'Hominum'),
-        StringStruct(u'ProductVersion', u'1.3.3.2')])
+        StringStruct(u'ProductVersion', u'1.4.3.3')])
       ]), 
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]

--- a/Launcher/source/mc/minecraft.py
+++ b/Launcher/source/mc/minecraft.py
@@ -23,8 +23,8 @@ from portablemc.standard import Context, Version, SimpleWatcher, Environment, St
     JvmLoadingEvent, JvmLoadedEvent, JarFoundEvent, \
     AssetsResolveEvent, LibrariesResolvingEvent, LibrariesResolvedEvent, LoggerFoundEvent
 from portablemc.fabric import FabricVersion, FabricResolveEvent
-from portablemc.forge import ForgeVersion, ForgeResolveEvent, ForgePostProcessingEvent, \
-    ForgePostProcessedEvent
+from portablemc.forge import ForgeVersion, _NeoForgeVersion, \
+    ForgeResolveEvent, ForgePostProcessingEvent, ForgePostProcessedEvent
 
 logger = logging.getLogger(__name__)
 
@@ -299,7 +299,7 @@ class MCManager:
         - mc_version (str): Version of Minecraft.
         - loader_version (str): Version of the loader.
 
-        Returns
+        Returns:
         - FabricVersion: Fabric version.
         """
         logger.debug("mc_version: %s", mc_version)
@@ -320,7 +320,7 @@ class MCManager:
         - mc_version (str): Version of Minecraft.
         - loader_version (str): Version of the loader.
 
-        Returns
+        Returns:
         - FabricVersion: Quilt version.
         """
         logger.debug("mc_version: %s", mc_version)
@@ -339,7 +339,7 @@ class MCManager:
         - mc_version (str): Version of Minecraft.
         - forge_version (str): Version of forge.
 
-        Returns
+        Returns:
         - ForgeVersion: Forge version.
         """
         logger.debug("mc_version: %s", mc_version)
@@ -352,6 +352,20 @@ class MCManager:
             forge = "release"
             logger.warning("Forge MC version set to None, ignoring forge version")
         return ForgeVersion(forge_version=forge, context=self.context)
+
+    def create_neoforge_version(self, mc_version: str=None) -> _NeoForgeVersion:
+        """
+        Create neoforge root.
+        Specific neoforge version not available yet.
+
+        Parameters:
+        - mc_version (str): Version of Minecraft.
+
+        Returns:
+        - _NeoForgeVersion: Neoforge version.
+        """
+        logger.debug("mc_version: %s", mc_version)
+        return _NeoForgeVersion(neoforge_version=mc_version)
 
     def provision_version(self, autojoin: bool) -> Version | FabricVersion | ForgeVersion:
         """
@@ -385,6 +399,10 @@ class MCManager:
         elif self.game_selected == "forge":
             version = self.create_forge_version(
                 mc_version=game_config["mc_version"], forge_version=game_config["forge_version"]
+            )
+        elif self.game_selected == "neoforge":
+            version = self.create_neoforge_version(
+                mc_version=game_config["mc_version"]
             )
         else:
             raise ValueError(f"Unknown valid game selected: {self.game_selected}")

--- a/Launcher/source/mc/minecraft.py
+++ b/Launcher/source/mc/minecraft.py
@@ -365,7 +365,7 @@ class MCManager:
         - _NeoForgeVersion: Neoforge version.
         """
         logger.debug("mc_version: %s", mc_version)
-        return _NeoForgeVersion(neoforge_version=mc_version)
+        return _NeoForgeVersion(neoforge_version=mc_version, context=self.context)
 
     def provision_version(self, autojoin: bool) -> Version | FabricVersion | ForgeVersion:
         """

--- a/Launcher/source/path.py
+++ b/Launcher/source/path.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 PROGRAM_NAME = "Hominum"
 PROGRAM_NAME_LONG = "Hominum Launcher"
-VERSION = "1.3.3.2"
+VERSION = "1.4.3.3"
 
 if getattr(sys, 'frozen', False):
     APPLICATION_DIR = pathlib.Path(sys.executable).parent

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ startup:
   * mc_version `"", ~, "x.x.x"` - The version of minecraft. If this is null, forge version will be force to be recommended
   * forge_version `"", ~, "x.x.x", recommended, latest` - The version of forge. Recommended is default
 
+* neoforge - Neoforge Game Type
+  * mc_version `"", ~, "x.x.x"` - The version of minecraft
+
 #### Games Example
 
 ```yaml
@@ -59,6 +62,8 @@ games:
   forge:
     mc_version: "1.20.1"
     forge_version: "47.3.0"
+  neoforge:
+    mc_version: "1.20.1"
 ```
 
 ### paths :heavy_plus_sign:


### PR DESCRIPTION
Adds neoforge versioning methods.

The specific version of neoforge is not **yet** selectable due to how new the loader is.

Babric support was not added due to limited use cases.