### PR TITLE
Bugfix/Altnames Crash Condition

### DIFF
--- a/Compile Info/Specs.py
+++ b/Compile Info/Specs.py
@@ -2,7 +2,7 @@ import pyinstaller_versionfile
 
 pyinstaller_versionfile.create_versionfile(
     output_file="versionfile.txt",
-    version="1.4.5.5",
+    version="1.4.6.6",
     company_name="Noah Blaszak",
     file_description="Hominum Minecraft Launcher",
     internal_name="Hominum Client",

--- a/Compile Info/versionfile.txt
+++ b/Compile Info/versionfile.txt
@@ -7,8 +7,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0. Must always contain 4 elements.
-    filevers=(1,4,5,5),
-    prodvers=(1,4,5,5),
+    filevers=(1,4,6,6),
+    prodvers=(1,4,6,6),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -32,12 +32,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'Noah Blaszak'),
         StringStruct(u'FileDescription', u'Hominum Minecraft Launcher'),
-        StringStruct(u'FileVersion', u'1.4.5.5'),
+        StringStruct(u'FileVersion', u'1.4.6.6'),
         StringStruct(u'InternalName', u'Hominum Client'),
         StringStruct(u'LegalCopyright', u'© Noah Blaszak. All rights reserved.'),
         StringStruct(u'OriginalFilename', u'Hominum.exe'),
         StringStruct(u'ProductName', u'Hominum'),
-        StringStruct(u'ProductVersion', u'1.4.5.5')])
+        StringStruct(u'ProductVersion', u'1.4.6.6')])
       ]), 
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]

--- a/Launcher/source/gui/app_win.py
+++ b/Launcher/source/gui/app_win.py
@@ -137,7 +137,9 @@ class RightFrame(customtkinter.CTkFrame):
             )
             username = self.auth_handler.get_username()
             if username:
-                altnames: dict = mcmanager.remote_config.get("altnames", {})
+                altnames: dict | None = mcmanager.remote_config.get("altnames", {})
+                if not altnames:
+                    altnames = {}
                 if username in altnames:
                     username = altnames[username]
                 self.user_menu_var = customtkinter.StringVar(value=username)

--- a/Launcher/source/path.py
+++ b/Launcher/source/path.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 PROGRAM_NAME = "Hominum"
 PROGRAM_NAME_LONG = "Hominum Launcher"
-VERSION = "1.4.5.5"
+VERSION = "1.4.6.6"
 
 if getattr(sys, 'frozen', False):
     APPLICATION_DIR = pathlib.Path(sys.executable).parent

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ paths:
 
 ### altnames :heavy_plus_sign:
 
-Spoofs the players username to a alternate name in the launcher
+Spoofs the players username to a alternate name in the launcher. To disable this feature set the key as follows: `altnames: ~`
 
 #### Altnames Example
 


### PR DESCRIPTION
If the altnames option is set to `~` the launcher would crash on startup.

This fix forces the altnames to a empty dictionary if the value from the remote config is of a falsy type.