### PR TITLE
Bugfix/Cross File System Install

### DIFF
--- a/Compile Info/Specs.py
+++ b/Compile Info/Specs.py
@@ -2,7 +2,7 @@ import pyinstaller_versionfile
 
 pyinstaller_versionfile.create_versionfile(
     output_file="versionfile.txt",
-    version="1.4.8.9",
+    version="1.4.9.10",
     company_name="Noah Blaszak",
     file_description="Hominum Minecraft Launcher",
     internal_name="Hominum Client",

--- a/Compile Info/versionfile.txt
+++ b/Compile Info/versionfile.txt
@@ -7,8 +7,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0. Must always contain 4 elements.
-    filevers=(1,4,8,9),
-    prodvers=(1,4,8,9),
+    filevers=(1,4,9,10),
+    prodvers=(1,4,9,10),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -32,12 +32,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'Noah Blaszak'),
         StringStruct(u'FileDescription', u'Hominum Minecraft Launcher'),
-        StringStruct(u'FileVersion', u'1.4.8.9'),
+        StringStruct(u'FileVersion', u'1.4.9.10'),
         StringStruct(u'InternalName', u'Hominum Client'),
         StringStruct(u'LegalCopyright', u'© Noah Blaszak. All rights reserved.'),
         StringStruct(u'OriginalFilename', u'Hominum.exe'),
         StringStruct(u'ProductName', u'Hominum'),
-        StringStruct(u'ProductVersion', u'1.4.8.9')])
+        StringStruct(u'ProductVersion', u'1.4.9.10')])
       ]), 
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]

--- a/Launcher/source/mc/remote.py
+++ b/Launcher/source/mc/remote.py
@@ -26,7 +26,7 @@ import time
 import os
 import requests
 import yaml
-from source import creds, exceptions
+from source import path, creds, exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ def decode_base64(file_path: str, chunk_size=8192) -> None:
         # Create a temporary file to store decoded content
         logger.debug("Decoding base64 content from '%s'", file_path)
         with open(file_path, "rb") as file:
-            temp_decode_file = tempfile.NamedTemporaryFile(delete=False)
+            temp_decode_file = tempfile.NamedTemporaryFile(dir=path.DOWNLOAD_DIR, delete=False)
             with temp_decode_file:
                 while True:
                     # Read the next chunk from the raw file
@@ -176,7 +176,7 @@ def download(url: str = None, save_path: str = None, chunk_size=8192) -> str | N
 
         # write raw content to file
         logger.debug("Downloading '%s'", url)
-        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        with tempfile.NamedTemporaryFile(dir=path.DOWNLOAD_DIR, delete=False) as temp_file:
             for chunk in resp.iter_content(chunk_size=chunk_size):
                 if chunk:
                     temp_file.write(chunk)
@@ -228,12 +228,12 @@ def get_repo_tree() -> dict:
     return tree
 
 
-def get_file_url(tree: dict, path: str) -> dict:
+def get_file_url(tree: dict, dir_path: str) -> dict:
     """
     Retrieves the download URL for the specified file from the server.
 
     Parameters:
-    - path (str): The path to the file on the server.
+    - dir_path (str): The path to the file on the server.
 
     Returns:
     - dict: The download URL for the file.
@@ -242,9 +242,9 @@ def get_file_url(tree: dict, path: str) -> dict:
     if not tree:
         return None
     for file in tree:
-        if file["path"] == path:
+        if file["path"] == dir_path:
             return file["url"]
-    logger.error("'%s' not found on the server", path)
+    logger.error("'%s' not found on the server", dir_path)
 
     return None
 

--- a/Launcher/source/path.py
+++ b/Launcher/source/path.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 PROGRAM_NAME = "Hominum"
 PROGRAM_NAME_LONG = "Hominum Launcher"
-VERSION = "1.4.8.9"
+VERSION = "1.4.9.10"
 
 if getattr(sys, 'frozen', False):
     APPLICATION_DIR = pathlib.Path(sys.executable).parent

--- a/Launcher/source/path.py
+++ b/Launcher/source/path.py
@@ -32,17 +32,12 @@ else:
     APPLICATION_DIR = pathlib.Path(__file__).parents[1]
 
 ASSETS_DIR = pathlib.Path(os.path.join(APPLICATION_DIR, "assets"))
-
-if os.name == "posix":
-    STORE_DIR = os.path.join(os.getenv("HOME"), ".hominum")
-else:
-    STORE_DIR = os.path.join(APPLICATION_DIR, "Store")
-
-STORE_DIR = pathlib.Path(STORE_DIR)
+STORE_DIR = pathlib.Path(os.path.join(APPLICATION_DIR, "Store"))
 MAIN_DIR = pathlib.Path(os.path.join(STORE_DIR, "minecraft"))
 WORK_DIR = pathlib.Path(os.path.join(STORE_DIR, "mcdata"))
 CONTEXT = Context(MAIN_DIR, WORK_DIR)
 GLOBAL_KILL = pathlib.Path(os.path.join(STORE_DIR, "GLOBAL_KILL"))
+
 if GLOBAL_KILL.exists():
     GLOBAL_KILL.unlink()
 

--- a/Launcher/source/path.py
+++ b/Launcher/source/path.py
@@ -33,6 +33,7 @@ else:
 
 ASSETS_DIR = pathlib.Path(os.path.join(APPLICATION_DIR, "assets"))
 STORE_DIR = pathlib.Path(os.path.join(APPLICATION_DIR, "Store"))
+DOWNLOAD_DIR = pathlib.Path(os.path.join(STORE_DIR, "download"))
 MAIN_DIR = pathlib.Path(os.path.join(STORE_DIR, "minecraft"))
 WORK_DIR = pathlib.Path(os.path.join(STORE_DIR, "mcdata"))
 CONTEXT = Context(MAIN_DIR, WORK_DIR)
@@ -42,6 +43,7 @@ if GLOBAL_KILL.exists():
     GLOBAL_KILL.unlink()
 
 os.makedirs(STORE_DIR, exist_ok=True)
+os.makedirs(DOWNLOAD_DIR, exist_ok=True)
 os.makedirs(MAIN_DIR, exist_ok=True)
 os.makedirs(WORK_DIR, exist_ok=True)
 


### PR DESCRIPTION
Fixes an issue where the install fails if the launcher is installed on a disk other than the one where temp files are created.

* Creates a download folder where the application is located.
* MacOS doesn't have its own _.hominum_ folder anymore.