### PR TITLE
Feature/Same Instance Popup

### DIFF
--- a/Compile Info/Specs.py
+++ b/Compile Info/Specs.py
@@ -2,7 +2,7 @@ import pyinstaller_versionfile
 
 pyinstaller_versionfile.create_versionfile(
     output_file="versionfile.txt",
-    version="1.4.9.12",
+    version="1.5.9.13",
     company_name="Noah Blaszak",
     file_description="Hominum Minecraft Launcher",
     internal_name="Hominum Client",

--- a/Compile Info/versionfile.txt
+++ b/Compile Info/versionfile.txt
@@ -7,8 +7,8 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0. Must always contain 4 elements.
-    filevers=(1,4,9,12),
-    prodvers=(1,4,9,12),
+    filevers=(1,5,9,13),
+    prodvers=(1,5,9,13),
     # Contains a bitmask that specifies the valid bits 'flags'r
     mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -32,12 +32,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'Noah Blaszak'),
         StringStruct(u'FileDescription', u'Hominum Minecraft Launcher'),
-        StringStruct(u'FileVersion', u'1.4.9.12'),
+        StringStruct(u'FileVersion', u'1.5.9.13'),
         StringStruct(u'InternalName', u'Hominum Client'),
         StringStruct(u'LegalCopyright', u'© Noah Blaszak. All rights reserved.'),
         StringStruct(u'OriginalFilename', u'Hominum.exe'),
         StringStruct(u'ProductName', u'Hominum'),
-        StringStruct(u'ProductVersion', u'1.4.9.12')])
+        StringStruct(u'ProductVersion', u'1.5.9.13')])
       ]), 
     VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]

--- a/Launcher/main.py
+++ b/Launcher/main.py
@@ -13,6 +13,7 @@ import sys
 import psutil
 from source import path
 from source.gui.app_win import App
+from source.gui.popup_win import StandalonePopupWindow
 
 IS_DEVELOPMENT = False  # This should be set to False before release
 
@@ -107,10 +108,6 @@ if __name__ == "__main__":
     application_errors = configure_logging()
     logger = logging.getLogger(__name__)
 
-    if not IS_DEVELOPMENT and is_process_running():
-        logger.critical("Another instance of the updater is already running. Exiting...")
-        exit_application(1)
-
     # log constants
     logger.info("PROGRAM_NAME: %s", path.PROGRAM_NAME)
     logger.info("PROGRAM_NAME_LONG: %s", path.PROGRAM_NAME_LONG)
@@ -126,8 +123,16 @@ if __name__ == "__main__":
     try:
         logger.info("Starting application")
 
-        app = App()
-        app.mainloop()
+        if not IS_DEVELOPMENT and is_process_running():
+            logger.critical("Another instance of the launcher is already running")
+            instance_popup = StandalonePopupWindow(
+                title="Another instance is running",
+                message="Another instance of the launcher is already running.",
+            )
+            instance_popup.mainloop()
+        else:
+            app = App()
+            app.mainloop()
 
         if application_errors.error_occurred:
             logger.warning("Application finished with errors")

--- a/Launcher/source/gui/popup_win.py
+++ b/Launcher/source/gui/popup_win.py
@@ -3,6 +3,7 @@ Contains the PopupWindow class
 
 Classes:
 - PopupWindow: Popup window
+- StandalonePopupWindow: Standalone popup window
 """
 
 import logging
@@ -25,13 +26,11 @@ class PopupWindow(customtkinter.CTkToplevel):
 
         self.title(title)
         self.attributes("-topmost", True)
+        self.transient(master)
         self.geometry("500x200")
         self.resizable(False, False)
         self.grid_columnconfigure(0, weight=1)
         self.grid_rowconfigure(0, weight=1)
-
-        # Make the window modal
-        self.transient(master)  # Set to be a transient window of the master window
 
         # Scrollable frame
         self.message_frame = customtkinter.CTkScrollableFrame(self)
@@ -50,3 +49,39 @@ class PopupWindow(customtkinter.CTkToplevel):
         self.button.grid(row=1, column=0, padx=20, pady=(0, 20), sticky="s")
 
         logger.debug("Popup window created")
+
+
+class StandalonePopupWindow(customtkinter.CTk):
+    """Standalone popup window for displaying messages."""
+    def __init__(self, title, message, **kwargs):
+        super().__init__(**kwargs)
+        logger.debug("Creating standalone popup window")
+
+        self.settings = utils.Settings()
+
+        logger.debug("Standalone Popup window title: %s", title)
+        logger.debug("Standalone Popup window message: %s", message)
+
+        self.title(title)
+        self.geometry("500x200")
+        self.resizable(False, False)
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(0, weight=1)
+
+        # Scrollable frame
+        self.message_frame = customtkinter.CTkScrollableFrame(self)
+        self.message_frame.grid(row=0, column=0, padx=20, pady=20, sticky="new")
+
+        self.label = customtkinter.CTkLabel(
+            self.message_frame,
+            text=message,
+            font=self.settings.get_gui("font_large"), wraplength=400
+        )
+        self.label.grid(row=0, column=0, padx=20, pady=20)
+
+        self.button = customtkinter.CTkButton(
+            self, text="OK", command=self.destroy, font=self.settings.get_gui("font_normal")
+        )
+        self.button.grid(row=1, column=0, padx=20, pady=(0, 20), sticky="s")
+
+        logger.debug("Standalone popup window created")

--- a/Launcher/source/path.py
+++ b/Launcher/source/path.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 PROGRAM_NAME = "Hominum"
 PROGRAM_NAME_LONG = "Hominum Launcher"
-VERSION = "1.4.9.12"
+VERSION = "1.5.9.13"
 
 if getattr(sys, 'frozen', False):
     APPLICATION_DIR = pathlib.Path(sys.executable).parent


### PR DESCRIPTION
If another launcher instance is running the new instance is closed with no error info other than logs. This update adds a standalone popup window that's used to display what exactly went wrong.

In addition error handling of this scenario has been improved by moving the condition into the main try-except block.